### PR TITLE
Add support for variable sizing of rows and columns 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+.DS_Store
+/split_images
 /target

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,11 +124,14 @@ fn split_image(img_path: &PathBuf, rows: Vec<u32>, cols: Vec<u32>) -> Vec<Dynami
     let row_height = height / sum_rows;
     let col_width = width / sum_cols;
 
+    let mut x = 0;
+    let mut y = 0;
+
     for i in 0..rows.len() {
-        let y = if i == 0 {
+        y = if i == 0 {
             0
         } else {
-            i as u32 + row_height * rows[i - 1]
+            y + row_height * rows[i - 1]
         };
 
         let crop_height = if i == rows.len() - 1 {
@@ -138,10 +141,10 @@ fn split_image(img_path: &PathBuf, rows: Vec<u32>, cols: Vec<u32>) -> Vec<Dynami
         };
 
         for j in 0..cols.len() {
-            let x = if j == 0 {
+            x = if j == 0 {
                 0
             } else {
-                j as u32 + col_width * cols[j - 1]
+                x as u32 + col_width * cols[j - 1]
             };
 
             let crop_width = if j == cols.len() - 1 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,12 +11,22 @@ struct Cli {
     #[arg(short, long)]
     image: PathBuf,
 
-    /// Number of rows to split the image into.
-    #[arg(short, long, value_delimiter = ',')]
+    /// The number of rows to split the image into.
+    /// You can either specify an integer, or a list of integers:
+    /// -r 4        This will split the image into 4 equal rows
+    /// -r 2,3,1,5  This will split the image into four rows of different heights.
+    ///             The image will be divided vertically into 2+3+1+5=11 equal sections.
+    ///             The first row will take up 2 sections, second row 3 sections, etc.
+    #[arg(short, long, value_delimiter = ',', verbatim_doc_comment)]
     rows: Option<Vec<u32>>,
 
-    /// Number of columns to split the image into.
-    #[arg(short, long, value_delimiter = ',')]
+    /// The number of columns to split the image into.
+    /// You can either specify an integer, or a list of integers.
+    /// -c 4        This will split the image into 4 equal rows):
+    /// -c 2,3,1,5  This will split the image into four columns of different widths.
+    ///             The image will be divided horizontally into 2+3+1+5=11 equal sections.
+    ///             The first column will take up 2 sections, second column 3 sections, etc.
+    #[arg(short, long, value_delimiter = ',', verbatim_doc_comment)]
     cols: Option<Vec<u32>>,
 }
 
@@ -65,13 +75,13 @@ fn validate_args(cli: &Cli) -> Result<(), String> {
     Ok(())
 }
 
-/// Splits the input image into specified number of rows and columns.
+/// Splits the input image into the specified number of rows and columns.
 ///
 /// # Arguments
 ///
 /// * `img_path` - Path to the input image file.
-/// * `rows` - Number of rows to split the image into.
-/// * `cols` - Number of columns to split the image into.
+/// * `rows` - Number of rows to split the image into. Provide a single integer for equal division, or a list of integers for custom division.
+/// * `cols` - Number of columns to split the image into. Provide a single integer for equal division, or a list of integers for custom division.
 ///
 /// # Returns
 ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use image::*;
 use std::path::PathBuf;
-use std::{fs, vec};
+use std::{fs, process, vec};
 
 /// Command-line arguments for splix.
 #[derive(Parser)]
@@ -93,6 +93,41 @@ fn split_image(img_path: &PathBuf, rows: Vec<u32>, cols: Vec<u32>) -> Vec<Dynami
     let sum_rows: u32 = rows.iter().sum();
     let sum_cols: u32 = cols.iter().sum();
 
+    if sum_rows > height {
+        eprintln!(
+            "splix: rows: The sum of provided rows ({}) exceeds image height ({})",
+            sum_rows, height
+        );
+        process::exit(1);
+    }
+
+    if sum_cols > width {
+        eprintln!(
+            "splix: cols: The sum of provided columns ({}) exceedsd image width ({})",
+            sum_cols, width
+        );
+        process::exit(1);
+    }
+
+    let rows = if rows.len() > 1 {
+        rows
+    } else {
+        vec![1; rows[0] as usize]
+    };
+
+    let cols = if cols.len() > 1 {
+        cols
+    } else {
+        vec![1; cols[0] as usize]
+    };
+    for val in &rows {
+        println!("rows {}", val);
+    }
+
+    for val in &cols {
+        println!("cols {}", val);
+    }
+
     let row_height = height / sum_rows;
     let col_width = width / sum_cols;
 
@@ -113,8 +148,9 @@ fn split_image(img_path: &PathBuf, rows: Vec<u32>, cols: Vec<u32>) -> Vec<Dynami
             let x = if j == 0 {
                 0
             } else {
-                j as u32 + col_width + cols[j - 1]
+                j as u32 + col_width * cols[j - 1]
             };
+            println!("{} {}", x, y);
             let crop_width = if j == cols.len() - 1 {
                 width - x
             } else {
@@ -126,6 +162,7 @@ fn split_image(img_path: &PathBuf, rows: Vec<u32>, cols: Vec<u32>) -> Vec<Dynami
         }
     }
 
+    println!("{}", split_images.len());
     split_images
 }
 
@@ -176,9 +213,8 @@ mod tests {
     fn test_split_image_correct_number_of_images() {
         let path = &PathBuf::from("./assets/16x16.png");
         assert!(split_image(path, vec![3], vec![5]).len() == 15);
-        assert!(split_image(path, vec![0], vec![0]).len() == 1);
+        assert!(split_image(path, vec![1], vec![1]).len() == 1);
         assert!(split_image(path, vec![16], vec![16]).len() == 256);
-        assert!(split_image(path, vec![17], vec![17]).len() == 256);
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,13 +120,6 @@ fn split_image(img_path: &PathBuf, rows: Vec<u32>, cols: Vec<u32>) -> Vec<Dynami
     } else {
         vec![1; cols[0] as usize]
     };
-    for val in &rows {
-        println!("rows {}", val);
-    }
-
-    for val in &cols {
-        println!("cols {}", val);
-    }
 
     let row_height = height / sum_rows;
     let col_width = width / sum_cols;
@@ -150,7 +143,7 @@ fn split_image(img_path: &PathBuf, rows: Vec<u32>, cols: Vec<u32>) -> Vec<Dynami
             } else {
                 j as u32 + col_width * cols[j - 1]
             };
-            println!("{} {}", x, y);
+
             let crop_width = if j == cols.len() - 1 {
                 width - x
             } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use image::*;
 use std::path::PathBuf;
 use std::{fs, vec};
 
+// TODO: update docs
 /// Command-line arguments for splix.
 #[derive(Parser)]
 struct Cli {
@@ -42,7 +43,23 @@ fn validate_args(cli: &Cli) -> Result<(), String> {
     }
 
     if rows.is_none() && cols.is_none() {
-        return Err("splix: At least one of '--rows', '--cols' needs to be specified.".to_string());
+        return Err("splix: At least one of '--rows', '--cols' needs to be specified".to_string());
+    }
+
+    if let Some(rows) = rows {
+        for row_val in rows {
+            if *row_val == 0 {
+                return Err("splix: rows: Row size(s) must be greater than zero".to_string());
+            }
+        }
+    }
+
+    if let Some(cols) = cols {
+        for col_val in cols {
+            if *col_val == 0 {
+                return Err("splix: cols: Column size(s) must be greater than zero".to_string());
+            }
+        }
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,6 @@ use image::*;
 use std::path::PathBuf;
 use std::{fs, vec};
 
-// TODO: update docs
 /// Command-line arguments for splix.
 #[derive(Parser)]
 struct Cli {

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,26 +81,36 @@ fn split_image(img_path: &PathBuf, rows: Vec<u32>, cols: Vec<u32>) -> Vec<Dynami
     let mut split_images = Vec::new();
     let (width, height) = img.dimensions();
 
-    let rows = rows[0];
-    let cols = cols[0];
+    let sum_rows: u32 = rows.iter().sum();
+    let sum_cols: u32 = cols.iter().sum();
 
-    let rows = rows.clamp(1, height);
-    let cols = cols.clamp(1, width);
+    let row_height = height / sum_rows;
+    let col_width = width / sum_cols;
 
-    let row_height = height / rows;
-    let col_width = width / cols;
-
-    for i in 0..rows {
-        let y = row_height * i;
-        let crop_height = if i == rows - 1 {
-            height - y
+    for i in 0..rows.len() {
+        let y = if i == 0 {
+            0
         } else {
-            row_height
+            i as u32 + row_height * rows[i - 1]
         };
 
-        for j in 0..cols {
-            let x = col_width * j;
-            let crop_width = if j == cols - 1 { width - x } else { col_width };
+        let crop_height = if i == rows.len() - 1 {
+            height - y
+        } else {
+            row_height * rows[i]
+        };
+
+        for j in 0..cols.len() {
+            let x = if j == 0 {
+                0
+            } else {
+                j as u32 + col_width + cols[j - 1]
+            };
+            let crop_width = if j == cols.len() - 1 {
+                width - x
+            } else {
+                col_width * cols[j]
+            };
 
             let sub_img = img.crop(x, y, crop_width, crop_height);
             split_images.push(sub_img);

--- a/src/main.rs
+++ b/src/main.rs
@@ -162,7 +162,6 @@ fn split_image(img_path: &PathBuf, rows: Vec<u32>, cols: Vec<u32>) -> Vec<Dynami
         }
     }
 
-    println!("{}", split_images.len());
     split_images
 }
 


### PR DESCRIPTION
## Description
This pull request adds support for variable sizing of rows and columns when splitting images. Previously, only integer arguments were accepted for `--rows` and `--cols` options. Users can now provide a single integer for equal division or a list of integers for custom division of rows and columns.

## Changes Made
- Updated the `Cli` struct in the `splix` CLI tool to accept vectors of `u32` for `rows` and `cols`.
- Updated the `split_image` function to accept vectors of `u32` for variable sizing of rows and columns.

## Example Usage
```shell
# Example usage with equal division of rows and columns
splix --image "example.jpg" --rows 2 --cols 3

# Example usage with custom division of rows and columns
splix --image "example.jpg" --rows 1,2,1 --cols 3,2,1
