### PR TITLE
Add support for splitting all images in a directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -816,6 +816,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -886,6 +895,7 @@ version = "0.1.1"
 dependencies = [
  "clap",
  "image",
+ "walkdir",
 ]
 
 [[package]]
@@ -1019,6 +1029,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1083,6 +1103,37 @@ name = "weezl"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ categories = ["command-line-utilities"]
 [dependencies]
 clap = { version = "4.5.4", features = ["derive"] }
 image = "0.25.1"
+walkdir = "2.5.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,10 @@ struct Cli {
     /// Directory to save the splixed images in. Default: `./splixed-images`.
     #[arg(short = 'o', long = "output-dir")]
     output_dir: Option<PathBuf>,
+
+    /// Enable recursive search for images in specified directory.
+    #[arg(short = 'R', long)]
+    recursive: bool,
 }
 
 /// Validates the provided command-line arguments.
@@ -242,8 +246,13 @@ fn main() {
     let rows = cli.rows.unwrap_or(vec![1]);
     let cols = cli.cols.unwrap_or(vec![1]);
     let output_directory = cli.output_dir.unwrap_or(PathBuf::from("splixed-images"));
+    let entries = if cli.recursive {
+        WalkDir::new(&img_dir)
+    } else {
+        WalkDir::new(&img_dir).max_depth(1)
+    };
 
-    for entry in WalkDir::new(&img_dir) {
+    for entry in entries {
         match entry {
             Ok(entry) => {
                 if let Ok(img) = image::open(entry.path()) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,7 +100,7 @@ fn validate_args(cli: &Cli) -> Result<(), String> {
 ///
 /// # Arguments
 ///
-/// * `img_path` - Path to the input image file.
+/// * `img` - Image to split.
 /// * `rows` - Number of rows to split the image into. Provide a single integer for equal division, or a list of integers for custom division.
 /// * `cols` - Number of columns to split the image into. Provide a single integer for equal division, or a list of integers for custom division.
 ///
@@ -190,9 +190,12 @@ fn split_image(mut img: DynamicImage, rows: &Vec<u32>, cols: &Vec<u32>) -> Vec<D
 /// # Arguments
 ///
 /// * `split_images` - A reference to a vector containing the split images.
-/// * `save_directory_str` - Path to the directory where split images will be saved.
+/// * `output_directory` - Path to the directory where split images will be saved.
+/// * `img_file_name` - Path of image excluding parent directories and extension.
 /// * `img_format` - Format of the image.
 /// * `img_format_str` - String representation of the image format.
+/// * `num_rows` - Number of rows the image was split into.
+/// * `num_cols` _ Number of columns the image was split into.
 fn save_images(
     split_images: &Vec<DynamicImage>,
     output_directory: &PathBuf,

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,18 +11,18 @@ struct Cli {
     image: PathBuf,
 
     /// The number of rows to split the image into.
-    /// You can either specify an integer, or a list of integers:
-    /// -r 4        This will split the image into 4 equal rows
-    /// -r 2,3,1,5  This will split the image into four rows of different heights.
+    /// Specify an integer, or a list of integers:
+    /// -r 4        Split the image into 4 equal rows.
+    /// -r 2,3,1,5  Split the image into four rows of different heights.
     ///             The image will be divided vertically into 2+3+1+5=11 equal sections.
     ///             The first row will take up 2 sections, second row 3 sections, etc.
     #[arg(short, long, value_delimiter = ',', verbatim_doc_comment)]
     rows: Option<Vec<u32>>,
 
     /// The number of columns to split the image into.
-    /// You can either specify an integer, or a list of integers.
-    /// -c 4        This will split the image into 4 equal rows):
-    /// -c 2,3,1,5  This will split the image into four columns of different widths.
+    /// Speicty an integer, or a list of integers.
+    /// -c 4        Split the image into 4 equal columns.
+    /// -c 2,3,1,5  Split the image into four columns of different widths.
     ///             The image will be divided horizontally into 2+3+1+5=11 equal sections.
     ///             The first column will take up 2 sections, second column 3 sections, etc.
     #[arg(short, long, value_delimiter = ',', verbatim_doc_comment)]


### PR DESCRIPTION
## Description
This pull request allows users to specify a directory containing images to split. Additionally, it adds the option for recursive search through the entire directory tree to find images.

## Changes Made
- Modified the `image` (now `images`) argument to accept a single image or a directory.
- Added a new flag argument `-R` or `--recursive` to enable recursive search for images in the directory.
- Implemented logic to recursively search through the directory tree if the `-R` flag is provided.

## Example Usage
```shell
# Split all images in the specified directory (including subdirectories)
splix --images ~/Downloads -r 1,2,1 -c 2,1,2 -R
